### PR TITLE
Refactor/update schema sync code

### DIFF
--- a/prisma/migrations/20250522083810_add_default_status/migration.sql
+++ b/prisma/migrations/20250522083810_add_default_status/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "rental_requests" ALTER COLUMN "status" SET DEFAULT 'PENDING';

--- a/prisma/migrations/20250522090227_rename_rental_request_id/migration.sql
+++ b/prisma/migrations/20250522090227_rename_rental_request_id/migration.sql
@@ -1,0 +1,46 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `rental_requests_id` on the `completed_rentals` table. All the data in the column will be lost.
+  - You are about to drop the column `rental_requests_id` on the `notifications` table. All the data in the column will be lost.
+  - You are about to drop the column `rental_requests_id` on the `payment_logs` table. All the data in the column will be lost.
+  - A unique constraint covering the columns `[rental_request_id]` on the table `completed_rentals` will be added. If there are existing duplicate values, this will fail.
+  - Added the required column `rental_request_id` to the `completed_rentals` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `rental_request_id` to the `payment_logs` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- DropForeignKey
+ALTER TABLE "completed_rentals" DROP CONSTRAINT "completed_rentals_rental_requests_id_fkey";
+
+-- DropForeignKey
+ALTER TABLE "notifications" DROP CONSTRAINT "notifications_rental_requests_id_fkey";
+
+-- DropForeignKey
+ALTER TABLE "payment_logs" DROP CONSTRAINT "payment_logs_rental_requests_id_fkey";
+
+-- DropIndex
+DROP INDEX "completed_rentals_rental_requests_id_key";
+
+-- AlterTable
+ALTER TABLE "completed_rentals" DROP COLUMN "rental_requests_id",
+ADD COLUMN     "rental_request_id" TEXT NOT NULL;
+
+-- AlterTable
+ALTER TABLE "notifications" DROP COLUMN "rental_requests_id",
+ADD COLUMN     "rental_request_id" TEXT;
+
+-- AlterTable
+ALTER TABLE "payment_logs" DROP COLUMN "rental_requests_id",
+ADD COLUMN     "rental_request_id" TEXT NOT NULL;
+
+-- CreateIndex
+CREATE UNIQUE INDEX "completed_rentals_rental_request_id_key" ON "completed_rentals"("rental_request_id");
+
+-- AddForeignKey
+ALTER TABLE "completed_rentals" ADD CONSTRAINT "completed_rentals_rental_request_id_fkey" FOREIGN KEY ("rental_request_id") REFERENCES "rental_requests"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "payment_logs" ADD CONSTRAINT "payment_logs_rental_request_id_fkey" FOREIGN KEY ("rental_request_id") REFERENCES "rental_requests"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "notifications" ADD CONSTRAINT "notifications_rental_request_id_fkey" FOREIGN KEY ("rental_request_id") REFERENCES "rental_requests"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -106,7 +106,7 @@ model RentalRequest {
   id              String           @id @default(uuid())
   startDate       DateTime         @map("start_date")
   endDate         DateTime         @map("end_date")
-  status          RequestStatus
+  status          RequestStatus    @default(PENDING)
   totalPrice      Int              @map("total_price")
   howToReceive    ReceiveMethod    @map("how_to_receive")
   memo            String?          @db.Text
@@ -135,7 +135,7 @@ model CompletedRental {
   deletedAt       DateTime?     @map("deleted_at")
   userId          String        @map("user_id")
   productId       String        @map("product_id")
-  rentalRequestId String        @unique @map("rental_requests_id")
+  rentalRequestId String        @unique @map("rental_request_id")
   user            User          @relation(fields: [userId], references: [id])
   product         Product       @relation(fields: [productId], references: [id])
   rentalRequest   RentalRequest @relation(fields: [rentalRequestId], references: [id])
@@ -151,7 +151,7 @@ model PaymentLog {
   paidAt          DateTime?
   memo            String?
   createdAt       DateTime      @default(now()) @map("created_at")
-  rentalRequestId String        @map("rental_requests_id")
+  rentalRequestId String        @map("rental_request_id")
   rentalRequest   RentalRequest @relation(fields: [rentalRequestId], references: [id])
   userId          String        @map("user_id")
   user            User          @relation(fields: [userId], references: [id])
@@ -171,7 +171,7 @@ model Notification {
   user               User              @relation(fields: [userId], references: [id])
   productId          String?           @map("product_id")
   product            Product?          @relation(fields: [productId], references: [id])
-  rentalRequestId    String?           @map("rental_requests_id")
+  rentalRequestId    String?           @map("rental_request_id")
   rentalRequest      RentalRequest?    @relation(fields: [rentalRequestId], references: [id])
   reviewId           String?           @map("review_id")
   review             RentalReview?     @relation(fields: [reviewId], references: [id])

--- a/src/repositories/product.repository.js
+++ b/src/repositories/product.repository.js
@@ -50,6 +50,8 @@ export const getProductById = async (id) => {
 		include: {
 			owner: true,
 			category: true,
+			RentalReview: true,
+			statusLogs: true,
 		},
 	});
 };

--- a/src/services/product.service.js
+++ b/src/services/product.service.js
@@ -198,13 +198,18 @@ export const deleteProduct = async (id, user) => {
 	if (product.ownerId !== user.id && user.role !== "ADMIN") {
 		throw new Error(ERROR_MESSAGES.NO_PERMISSION);
 	}
-
+	const now = new Date();
+	const oneMonthLater = new Date();
+	oneMonthLater.setDate(now.getDate() + 30);
 	// 예약되었거나 대여중이면 삭제 금지
 	const activeRental = await prisma.rentalRequest.findFirst({
 		where: {
 			productId: id,
 			status: {
 				in: ["APPROVED", "ON_RENTING"],
+			},
+			startDate: {
+				lte: oneMonthLater,
 			},
 		},
 	});

--- a/todo.md
+++ b/todo.md
@@ -28,3 +28,5 @@ STORAGE_FEE (장기 보관료)
 DAMAGE_COMPENSATION (파손/손상 보상금)
 OWNER_PAYOUT (소유주 정산금 지급)
 REFUND (환불)
+
+반사적으로 박았는데 사실 profileimage라는건 필요없는게 아닐까 user에 어차피 admin하고만 노는데 근데 확장가능성있으니 넣어두고 반환값을 수정하자 안보이게 잘 숨겨서 ㅇㅇ


### PR DESCRIPTION
 schema변경으로 인한 refactor 
rental_requests_id → rental_request_id 통일
rentalRequest 관련 비즈니스 로직 개선 -> 30일 제한, totalPrice, howToReceive 등
deleteProduct() 로직 보강 -> 예약/대여 중일 시 삭제 제한
Prisma 마이그레이션 리셋 + 재적용 ->  schema ↔ DB 동기화 완료
seed 정상 적용  -> 기타 카테고리 확인됨
아직 더있을수도..
