### PR TITLE
fix/bankFieldDelete-fixVerifiedPhone

### DIFF
--- a/src/services/user.service.js
+++ b/src/services/user.service.js
@@ -7,50 +7,47 @@ import {USER_MESSAGES} from "../constants/messages.js";
 export const getUserById = async (userId) => {
 	const user = await findUserById(userId);
 	if (!user) throw new CustomError(404, "USER_NOT_FOUND", USER_MESSAGES.USER_NOT_FOUND);
-	const { id, name, phone, verifiedPhone, bankAccount, bankName, accountHolder, verifiedBankAccount } = user;
-	return { id, name, phone, verifiedPhone, bankAccount, bankName, accountHolder, verifiedBankAccount };
+	const { id, name, phone, verifiedPhone } = user;
+	return { id, name, phone, verifiedPhone };
 };
 
 export const updateUserInfo = async (userId, { name, phone, bankAccount, bankName, accountHolder }) => {
 	const updateData = {};
-  
+
+	const user = await findUserById(userId);
+
 	if (phone && phone !== "00000000000") {
 	  const duplicate = await findValidUserByPhone(phone);
 	  if (duplicate && duplicate.id !== userId) {
 		throw new CustomError(409, "PHONE_EXISTS", USER_MESSAGES.PHONE_EXISTS);
 	  }
 	  updateData.phone = phone;
-	  updateData.verifiedPhone = false; 
+	  if (user.phone !== phone) {
+	    updateData.verifiedPhone = false;
+	  }
 	}
-  
+
 	if (name) updateData.name = name;
 	if (bankAccount !== undefined) updateData.bankAccount = bankAccount;
 	if (bankName !== undefined) updateData.bankName = bankName;
 	if (accountHolder !== undefined) updateData.accountHolder = accountHolder;
-  
+
 	const updatedUser = await updateUserById(userId, updateData);
 	const {
 	  id,
 	  name: updatedName,
 	  phone: updatedPhone,
 	  verifiedPhone,
-	  bankAccount: updatedBankAccount,
-	  bankName: updatedBankName,
-	  accountHolder: updatedAccountHolder,
-	  verifiedBankAccount,
 	} = updatedUser;
-  
+
 	return {
 	  id,
 	  name: updatedName,
 	  phone: updatedPhone,
 	  verifiedPhone,
-	  bankAccount: updatedBankAccount,
-	  bankName: updatedBankName,
-	  accountHolder: updatedAccountHolder,
-	  verifiedBankAccount,
 	};
   };
+  
 export const deactivateUser = async (userId) => {
 	return await softDeleteUserById(userId);
 };


### PR DESCRIPTION
충전관련 API 업데이트 전에 은행관련 필드를 사용하지 않을 것 같아 서비스에서 반환하지 않기로 수정하였습니다. 
내정보수정 핸드폰인증 관련하여 같은 값을 넘겨주어도 핸드폰인증이 해제되었었는데 같은 번호입력시에는 인증이 유지되게 변경하였습니다. 