### PR TITLE
fix/swagger-url-rollback

### DIFF
--- a/src/docs/swagger.js
+++ b/src/docs/swagger.js
@@ -13,7 +13,7 @@ const options = {
     },
     servers: [
       {
-        url: 'http://localhost:3000',
+        url: process.env.SWAGGER_SERVER_URL || 'http://localhost:3000',
       },
     ],
     tags: [


### PR DESCRIPTION
로컬에서 테스트 하기 위해 변경했던 swagger.js의 url을 ec2로 롤백하였슴다