### PR TITLE
fix/rentalRequest-concurrency

### DIFF
--- a/src/constants/messages.js
+++ b/src/constants/messages.js
@@ -115,6 +115,7 @@ export const RENTAL_REQUEST_MESSAGES = {
   USER_NOT_FOUND: "존재하지 않는 사용자입니다.",
   INSUFFICIENT_BALANCE: "잔고가 부족합니다.",
   ALREADY_REJECTED: "이미 거절/취소된 대여요청입니다.",
+  ALREADY_REQUESTED: "이미 대여요청이 존재합니다.",
 };
 
 export const MESSAGE_RESPONSES = {


### PR DESCRIPTION
rentalRequest 에서 
유저가 생성할때 -> 연속클릭
어드민이 거절 or 유저가취소 할때 -> 연속클릭 
을 방지하였습니다. 

rentalRequest 생성 시: 동일 유저/상품/기간에 이미 PENDING/APPROVED 상태의 요청이 있으면 중복 생성 방지

환불(취소/거절) 시: row-level lock + 조건부 updateMany로 한 번만 처리, 중복 로그/환불 방지

생성은 "존재 여부"만 체크하면 되지만,
상태 변경(취소/거절/환불 등)은
이미 처리된 상태로 바뀌었는지 "동시성"까지 신경 써야 하므로 락 + 조건부 update를 적용하였습니다. 