### PR TITLE
Feat/find id phone verification

### DIFF
--- a/src/constants/messages.js
+++ b/src/constants/messages.js
@@ -179,6 +179,9 @@ export const AUTH_MESSAGES = {
   NAVER_LOGIN_SUCCESS: '네이버 로그인 성공',
   LOGIN_SUCCESS: '로그인 성공',
   PHONE_REQUIRED: '전화번호를 입력해주세요.',
+  SUCCESS_CODE_SENT: '인증번호가 전송되었습니다.',
+  PHONE_VERIFICATION_SUCCESS: '전화번호 인증이 완료되었습니다.',
+  REJOIN_CODE_SENT: '재가입 인증코드가 이메일로 전송되었습니다.',
   INVALID_INPUT: '전화번호와 인증번호를 입력해주세요.',
   PASSWORD_MISMATCH: '비밀번호가 일치하지 않습니다.',
   EMAIL_EXISTS: '이미 가입된 이메일입니다.',
@@ -203,6 +206,7 @@ export const AUTH_MESSAGES = {
   PASSWORD_RESET_CODE_SENT:
     '비밀번호 재설정 인증코드가 이메일로 전송되었습니다.',
   PASSWORD_RESET_SUCCESS: '비밀번호가 성공적으로 변경되었습니다.',
+  ID_FIND_CODE_SENT: 'ID 찾기 인증코드가 전화번호로 전송되었습니다.',
 };
 
 export const USER_MESSAGES = {

--- a/src/constants/messages.js
+++ b/src/constants/messages.js
@@ -207,6 +207,8 @@ export const AUTH_MESSAGES = {
     '비밀번호 재설정 인증코드가 이메일로 전송되었습니다.',
   PASSWORD_RESET_SUCCESS: '비밀번호가 성공적으로 변경되었습니다.',
   ID_FIND_CODE_SENT: 'ID 찾기 인증코드가 전화번호로 전송되었습니다.',
+  MISSING_CODE: '인증번호를 입력해주세요.',
+  ID_FIND_SUCCESS: '분실하신 ID(이메일) 정보입니다.',
 };
 
 export const USER_MESSAGES = {

--- a/src/controllers/auth.controller.js
+++ b/src/controllers/auth.controller.js
@@ -5,20 +5,18 @@ import {
   rejoinRequest,
   rejoinVerify,
   verifyPhoneAndUpdateUser,
-  ensurePhoneExistsForVerification,
   logout,
   sendPasswordResetCode,
   verifyCodeAndChangePassword,
+  requestPhoneVerification,
+  findIdByPhone,
 } from '../services/auth.service.js';
 import { getRefreshToken, setRefreshToken } from '../utils/redis.js';
 import { verifyRefreshToken } from '../utils/jwt.js';
 import { generateTokens } from '../utils/jwt.js';
 import { success } from '../utils/responseHandler.js';
 import { AUTH_MESSAGES } from '../constants/messages.js';
-import {
-  sendVerificationCode,
-  verifyCode,
-} from '../utils/phoneVerification.js';
+import { verifyCode } from '../utils/phoneVerification.js';
 import CustomError from '../utils/customError.js';
 
 export const signupController = async (req, res, next) => {
@@ -130,7 +128,7 @@ export const rejoinRequestController = async (req, res, next) => {
   try {
     const { email } = req.body;
     await rejoinRequest(email);
-    return success(res, '인증 코드가 이메일로 전송되었습니다.');
+    return success(res, AUTH_MESSAGES.REJOIN_CODE_SENT);
   } catch (error) {
     next(error);
   }
@@ -200,19 +198,8 @@ export const socialCallbackController = async (req, res, next) => {
 export const requestPhoneCodeController = async (req, res, next) => {
   try {
     const { phone } = req.body;
-
-    if (!phone) {
-      throw new CustomError(
-        400,
-        'PHONE_REQUIRED',
-        AUTH_MESSAGES.PHONE_REQUIRED,
-      );
-    }
-
-    await ensurePhoneExistsForVerification(phone);
-    await sendVerificationCode(phone);
-
-    res.status(200).json({ message: '인증번호가 전송되었습니다.' });
+    await requestPhoneVerification(phone);
+    return success(res, AUTH_MESSAGES.SUCCESS_CODE_SENT);
   } catch (err) {
     next(err);
   }
@@ -230,7 +217,7 @@ export const verifyPhoneCodeController = async (req, res, next) => {
 
     await verifyPhoneAndUpdateUser(phone);
 
-    res.status(200).json({ message: '인증이 완료되었습니다.' });
+    return success(res, AUTH_MESSAGES.PHONE_VERIFICATION_SUCCESS);
   } catch (err) {
     next(err);
   }
@@ -256,6 +243,16 @@ export const passwordResetVerifyController = async (req, res, next) => {
       newPasswordCheck,
     });
     return success(res, AUTH_MESSAGES.PASSWORD_RESET_SUCCESS);
+  } catch (error) {
+    next(error);
+  }
+};
+
+export const findIdByPhoneController = async (req, res, next) => {
+  try {
+    const { phone } = req.body;
+    await findIdByPhone(phone);
+    return success(res, AUTH_MESSAGES.ID_FIND_CODE_SENT);
   } catch (error) {
     console.log(error);
     next(error);

--- a/src/controllers/auth.controller.js
+++ b/src/controllers/auth.controller.js
@@ -9,7 +9,8 @@ import {
   sendPasswordResetCode,
   verifyCodeAndChangePassword,
   requestPhoneVerification,
-  findIdByPhone,
+  findIdSendCodeByPhone,
+  findIdVerifyByPhone,
 } from '../services/auth.service.js';
 import { getRefreshToken, setRefreshToken } from '../utils/redis.js';
 import { verifyRefreshToken } from '../utils/jwt.js';
@@ -248,13 +249,22 @@ export const passwordResetVerifyController = async (req, res, next) => {
   }
 };
 
-export const findIdByPhoneController = async (req, res, next) => {
+export const findIdSendCodeByPhoneController = async (req, res, next) => {
   try {
     const { phone } = req.body;
-    await findIdByPhone(phone);
+    await findIdSendCodeByPhone(phone);
     return success(res, AUTH_MESSAGES.ID_FIND_CODE_SENT);
   } catch (error) {
-    console.log(error);
+    next(error);
+  }
+};
+
+export const findIdVerifyByPhoneController = async (req, res, next) => {
+  try {
+    const { phone, code } = req.body;
+    const result = await findIdVerifyByPhone({ phone, code });
+    return success(res, AUTH_MESSAGES.ID_FIND_SUCCESS, result);
+  } catch (error) {
     next(error);
   }
 };

--- a/src/routes/auth.routes.js
+++ b/src/routes/auth.routes.js
@@ -11,7 +11,8 @@ import {
   verifyPhoneCodeController,
   passwordResetRequestController,
   passwordResetVerifyController,
-  findIdByPhoneController,
+  findIdSendCodeByPhoneController,
+  findIdVerifyByPhoneController,
 } from '../controllers/auth.controller.js';
 import passport from '../configs/passport.js';
 
@@ -587,6 +588,56 @@ import passport from '../configs/passport.js';
  *         description: 해당 번호의 유저 없음
  */
 
+/**
+ * @swagger
+ * /api/auth/id/find/verify:
+ *   post:
+ *     summary: 휴대폰 인증번호로 ID(이메일) 찾기
+ *     description: 인증번호와 휴대폰 번호를 입력하면 마스킹된 이메일과 provider(LOCAL/SOCIAL)를 반환합니다.
+ *     tags: [Auth]
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required:
+ *               - phone
+ *               - code
+ *             properties:
+ *               phone:
+ *                 type: string
+ *                 example: "01012345678"
+ *               code:
+ *                 type: string
+ *                 example: "123456"
+ *     responses:
+ *       200:
+ *         description: 이메일 반환 성공
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 success:
+ *                   type: boolean
+ *                 message:
+ *                   type: string
+ *                 data:
+ *                   type: object
+ *                   properties:
+ *                     email:
+ *                       type: string
+ *                       example: abc****@gmail.com
+ *                     provider:
+ *                       type: string
+ *                       example: LOCAL
+ *       400:
+ *         description: 인증 실패(만료, 불일치, 잘못된 입력 등)
+ *       404:
+ *         description: 해당 번호의 유저 없음
+ */
+
 const router = express.Router();
 //회원가입
 router.post('/signup', signupController);
@@ -650,6 +701,9 @@ router.post('/password/reset/request', passwordResetRequestController);
 router.post('/password/reset/verify', passwordResetVerifyController);
 
 // 휴대폰 번호로 ID 찾기 요청
-router.post('/id/find/request', findIdByPhoneController);
+router.post('/id/find/request', findIdSendCodeByPhoneController);
+
+// 휴대폰 인증번호로 ID 찾기
+router.post('/id/find/verify', findIdVerifyByPhoneController);
 
 export default router;

--- a/src/routes/auth.routes.js
+++ b/src/routes/auth.routes.js
@@ -11,6 +11,7 @@ import {
   verifyPhoneCodeController,
   passwordResetRequestController,
   passwordResetVerifyController,
+  findIdByPhoneController,
 } from '../controllers/auth.controller.js';
 import passport from '../configs/passport.js';
 
@@ -549,6 +550,43 @@ import passport from '../configs/passport.js';
  *         description: 인증 실패(만료, 불일치, 잘못된 입력 등)
  */
 
+/**
+ * @swagger
+ * /api/auth/id/find/request:
+ *   post:
+ *     summary: 휴대폰 번호로 ID(이메일) 찾기 인증번호 발송
+ *     description: 입력한 휴대폰 번호로 인증번호를 전송합니다. 인증번호를 통해 ID(이메일) 찾기 검증을 진행할 수 있습니다.
+ *     tags: [Auth]
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required:
+ *               - phone
+ *             properties:
+ *               phone:
+ *                 type: string
+ *                 example: "01012345678"
+ *     responses:
+ *       200:
+ *         description: 인증번호 전송 성공
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 success:
+ *                   type: boolean
+ *                 message:
+ *                   type: string
+ *       400:
+ *         description: 잘못된 요청(번호 누락, 형식 오류 등)
+ *       404:
+ *         description: 해당 번호의 유저 없음
+ */
+
 const router = express.Router();
 //회원가입
 router.post('/signup', signupController);
@@ -610,5 +648,8 @@ router.post('/password/reset/request', passwordResetRequestController);
 
 // 비밀번호 재설정 인증코드 검증
 router.post('/password/reset/verify', passwordResetVerifyController);
+
+// 휴대폰 번호로 ID 찾기 요청
+router.post('/id/find/request', findIdByPhoneController);
 
 export default router;

--- a/src/services/auth.service.js
+++ b/src/services/auth.service.js
@@ -19,6 +19,8 @@ import {
   deleteEmailCode,
   setEmailCode,
   deleteRefreshToken,
+  getPhoneCode,
+  deletePhoneCode,
 } from '../utils/redis.js';
 import CustomError from '../utils/customError.js';
 import { AUTH_MESSAGES } from '../constants/messages.js';
@@ -27,6 +29,7 @@ import {
   sendPasswordResetEmail,
 } from '../utils/nodemailer.js';
 import { sendVerificationCode } from '../utils/phoneVerification.js';
+import { maskEmail } from '../utils/mask.js';
 
 export const signup = async ({
   email,
@@ -395,7 +398,7 @@ export const verifyCodeAndChangePassword = async ({
   await updatePasswordByEmail(account.id, hash);
 };
 
-export const findIdByPhone = async (phone) => {
+export const findIdSendCodeByPhone = async (phone) => {
   if (!phone || typeof phone !== 'string' || !/^\d{10,}$/.test(phone)) {
     throw new CustomError(
       400,
@@ -408,4 +411,41 @@ export const findIdByPhone = async (phone) => {
     throw new CustomError(404, 'USER_NOT_FOUND', AUTH_MESSAGES.USER_NOT_FOUND);
   }
   await sendVerificationCode(phone);
+};
+
+export const findIdVerifyByPhone = async ({ phone, code }) => {
+  if (!phone || typeof phone !== 'string' || !/^\d{10,}$/.test(phone)) {
+    throw new CustomError(
+      400,
+      'INVALID_PHONE',
+      AUTH_MESSAGES.INVALID_PHONE_ONLY_NUMBER,
+    );
+  }
+  if (!code) {
+    throw new CustomError(400, 'MISSING_CODE', AUTH_MESSAGES.MISSING_CODE);
+  }
+  const user = await findUserByPhone(phone);
+  if (!user) {
+    throw new CustomError(404, 'USER_NOT_FOUND', AUTH_MESSAGES.USER_NOT_FOUND);
+  }
+  // 인증코드 검증
+  const savedCode = await getPhoneCode(phone);
+  if (!savedCode) {
+    throw new CustomError(400, 'EXPIRED_CODE', AUTH_MESSAGES.EXPIRED_CODE);
+  }
+  if (savedCode !== code) {
+    throw new CustomError(400, 'INVALID_CODE', AUTH_MESSAGES.INVALID_CODE);
+  }
+  // 인증코드 삭제
+  await deletePhoneCode(phone);
+  // account에서 email, provider 조회
+  const account =
+    (await findByEmail(user.email)) || (await findAnyByEmail(user.email));
+  if (!account) {
+    throw new CustomError(404, 'USER_NOT_FOUND', AUTH_MESSAGES.USER_NOT_FOUND);
+  }
+  return {
+    email: maskEmail(account.email),
+    provider: account.provider,
+  };
 };

--- a/src/services/auth.service.js
+++ b/src/services/auth.service.js
@@ -26,6 +26,7 @@ import {
   sendRecoveryEmail,
   sendPasswordResetEmail,
 } from '../utils/nodemailer.js';
+import { sendVerificationCode } from '../utils/phoneVerification.js';
 
 export const signup = async ({
   email,
@@ -281,6 +282,14 @@ export const findOrCreateSocialAccount = async (profile, provider) => {
   return user;
 };
 
+export const requestPhoneVerification = async (phone) => {
+  if (!phone) {
+    throw new CustomError(400, 'PHONE_REQUIRED', AUTH_MESSAGES.PHONE_REQUIRED);
+  }
+  await ensurePhoneExistsForVerification(phone);
+  await sendVerificationCode(phone);
+};
+
 export const verifyPhoneAndUpdateUser = async (phone) => {
   const user = await findUserByPhone(phone);
   if (user && !user.verifiedPhone) {
@@ -384,4 +393,19 @@ export const verifyCodeAndChangePassword = async ({
   // 비밀번호 변경
   const hash = await bcrypt.hash(newPassword, 10);
   await updatePasswordByEmail(account.id, hash);
+};
+
+export const findIdByPhone = async (phone) => {
+  if (!phone || typeof phone !== 'string' || !/^\d{10,}$/.test(phone)) {
+    throw new CustomError(
+      400,
+      'INVALID_PHONE',
+      AUTH_MESSAGES.INVALID_PHONE_ONLY_NUMBER,
+    );
+  }
+  const user = await findUserByPhone(phone);
+  if (!user) {
+    throw new CustomError(404, 'USER_NOT_FOUND', AUTH_MESSAGES.USER_NOT_FOUND);
+  }
+  await sendVerificationCode(phone);
 };

--- a/src/services/review.service.js
+++ b/src/services/review.service.js
@@ -12,13 +12,7 @@ import { findProductByIdRepo } from '../repositories/product.repository.js';
 import CustomError from '../utils/customError.js';
 import { createNotification } from './notification.service.js';
 import { NOTIFICATION_MESSAGES } from '../constants/messages.js';
-
-// 이름 마스킹 함수
-export function maskName(name) {
-  if (!name) return '';
-  if (name.length <= 1) return '*';
-  return name[0] + '*'.repeat(name.length - 1);
-}
+import { maskName } from '../utils/mask.js';
 
 export const createReview = async (
   user,

--- a/src/utils/mask.js
+++ b/src/utils/mask.js
@@ -1,0 +1,14 @@
+// 이름 마스킹
+export function maskName(name) {
+  if (!name) return '';
+  if (name.length <= 1) return '*';
+  return name[0] + '*'.repeat(name.length - 1);
+}
+
+// 이메일 마스킹 (앞 5글자만 노출)
+export function maskEmail(email) {
+  if (!email) return '';
+  const [id, domain] = email.split('@');
+  if (id.length <= 3) return '*'.repeat(id.length) + '@' + domain;
+  return id.slice(0, 5) + '*'.repeat(id.length - 5) + '@' + domain;
+}


### PR DESCRIPTION
유저는 id 분실시 가입시 입력한 핸드폰으로 인증과정을 거치면 마스킹처리된 이메일(id)을 알 수 있습니다. 
id찾기 코드 요청 -> 코드, 폰번호입력 -> 이메일(id) 반환받음 

기존 review에서만 쓰던 마스킹 함수를 utils로 옮겼습니다. 

