### PR TITLE
Feat/ai prompt upgrade

### DIFF
--- a/prisma/seed.js
+++ b/prisma/seed.js
@@ -67,7 +67,10 @@ async function main() {
 
   // 인플루언서 계정 seeding
   const influencerUser = await prisma.user.findFirst({
-    where: { phone: INFLUENCER_PHONE },
+    where: {
+      phone: INFLUENCER_PHONE,
+      role: 'INFLUENCER',
+    },
   });
 
   if (!influencerUser) {

--- a/src/constants/messages.js
+++ b/src/constants/messages.js
@@ -265,6 +265,7 @@ export const PRODUCT_MESSAGES = {
   ALREADY_CANCELED_OR_INVALID: '이미 취소되었거나 구매 예약 상태가 아닙니다.',
   INVALID_DAYS: '유효한 날짜를 입력해주세요.',
   PRODUCT_STORAGE_FEE_LISTED: '보관료 부과 대상 상품 조회 성공',
+  INVALID_ALLOW_PURCHASE: 'allowPurchase는 boolean 값이어야 합니다.',
 };
 
 export const CATEGORY_MESSAGES = {

--- a/src/constants/messages.js
+++ b/src/constants/messages.js
@@ -47,6 +47,7 @@ export const AI_MESSAGES = {
   NO_PRODUCTS: '추천할 상품이 없습니다.',
   TOO_MANY_REQUESTS: '인증번호 요청은 잠시 후 다시 시도해주세요.',
   PRICE_ESTIMATION_SUCCESS: 'AI 적정가 분석 완료',
+  PRICE_ESTIMATION_STARTED: '상품 추정 가격 분석이 진행중입니다.',
   REVIEW_SUMMARY_SUCCESS: '리뷰 요약 완료',
   PRODUCT_RECOMMENDATION_SUCCESS: '상품 추천 완료',
   PRODUCT_NOT_FOUND: '상품을 찾을 수 없습니다.',

--- a/src/constants/messages.js
+++ b/src/constants/messages.js
@@ -52,6 +52,8 @@ export const AI_MESSAGES = {
   PRODUCT_RECOMMENDATION_SUCCESS: '상품 추천 완료',
   PRODUCT_NOT_FOUND: '상품을 찾을 수 없습니다.',
   REVIEW_NOT_FOUND: '리뷰를 찾을 수 없습니다.',
+  RECENT_PRICE_ESTIMATION_LIST_FETCHED:
+    '최근 AI 가격 추정 목록을 조회했습니다.',
 };
 
 export const PAYMENT_MESSAGES = {

--- a/src/controllers/ai.controller.js
+++ b/src/controllers/ai.controller.js
@@ -2,6 +2,7 @@ import {
   requestAiPriceEstimation,
   summarizeReviews,
   recommendProducts,
+  getRecentPriceEstimations,
 } from '../services/ai.service.js';
 import { success } from '../utils/responseHandler.js';
 import { AI_MESSAGES } from '../constants/messages.js';
@@ -35,6 +36,23 @@ export const recommendProductsController = async (req, res, next) => {
     const userId = req.user?.id ?? null;
     const result = await recommendProducts({ prompt, userId });
     return success(res, AI_MESSAGES.PRODUCT_RECOMMENDATION_SUCCESS, result);
+  } catch (err) {
+    next(err);
+  }
+};
+
+export const getRecentPriceEstimationsController = async (req, res, next) => {
+  try {
+    const { take = 20, skip = 0 } = req.query;
+    const result = await getRecentPriceEstimations({
+      take: parseInt(take),
+      skip: parseInt(skip),
+    });
+    return success(
+      res,
+      AI_MESSAGES.RECENT_PRICE_ESTIMATION_LIST_FETCHED,
+      result,
+    );
   } catch (err) {
     next(err);
   }

--- a/src/controllers/ai.controller.js
+++ b/src/controllers/ai.controller.js
@@ -13,7 +13,7 @@ export const requestAiPriceEstimationController = async (req, res, next) => {
 
     const result = await requestAiPriceEstimation({ productId, adminUser });
 
-    return success(res, AI_MESSAGES.PRICE_ESTIMATION_SUCCESS, result);
+    return success(res, result.message, result);
   } catch (err) {
     next(err);
   }

--- a/src/repositories/ai.repository.js
+++ b/src/repositories/ai.repository.js
@@ -4,6 +4,24 @@ export const saveAiPriceEstimation = async (data) => {
   return await prisma.aiPriceEstimation.create({ data });
 };
 
+export const getRecentAiPriceEstimations = async ({ take = 20, skip = 0 }) => {
+  return await prisma.aiPriceEstimation.findMany({
+    take,
+    skip,
+    orderBy: {
+      createdAt: 'desc',
+    },
+    include: {
+      product: {
+        select: {
+          id: true,
+          title: true,
+        },
+      },
+    },
+  });
+};
+
 export const saveAiProductRecommendation = async (data) => {
   return await prisma.aiProductRecommendation.create({ data });
 };

--- a/src/routes/ai.routes.js
+++ b/src/routes/ai.routes.js
@@ -33,7 +33,7 @@ const router = express.Router();
  *         description: 상품 ID
  *     responses:
  *       200:
- *         description: AI 적정가 분석 시작 응답
+ *         description: AI 적정가 분석 시작 응답 (백그라운드에서 분석 진행)
  *         content:
  *           application/json:
  *             schema:
@@ -59,6 +59,14 @@ const router = express.Router();
  *         description: 잘못된 요청(상품 상태 등)
  *       404:
  *         description: 상품 없음
+ *     x-codeSamples:
+ *       - lang: 'JavaScript'
+ *         source: |
+ *           // 분석 완료 후 결과는 GET /api/ai/price-estimation/history로 조회
+ *           // isValid 판단 기준:
+ *           // - 사용자 가격 ≤ 추정가의 70%: true (대여자에게 좋은 거래)
+ *           // - 사용자 가격 > 추정가의 150%: false (너무 비쌈)
+ *           // - 그 사이: AI가 종합적으로 판단
  */
 /**
  * @swagger
@@ -190,8 +198,14 @@ const router = express.Router();
  *                             type: integer
  *                           isValid:
  *                             type: boolean
+ *                             description: |
+ *                               가격 적정성 판단 (true/false)
+ *                               - 사용자 가격 ≤ 추정가의 70%: true (대여자에게 좋은 거래)
+ *                               - 사용자 가격 > 추정가의 150%: false (너무 비쌈)
+ *                               - 그 사이: AI가 종합적으로 판단
  *                           reason:
  *                             type: string
+ *                             description: 가격 적정성에 대한 구체적 설명 (시장 상황, 가격 비교, 추천 근거 포함)
  *                           sources:
  *                             type: object
  *                             properties:

--- a/src/routes/ai.routes.js
+++ b/src/routes/ai.routes.js
@@ -5,6 +5,7 @@ import {
   requestAiPriceEstimationController,
   summarizeReviewsController,
   recommendProductsController,
+  getRecentPriceEstimationsController,
 } from '../controllers/ai.controller.js';
 
 const router = express.Router();
@@ -156,5 +157,8 @@ router.post('/summary/:productId', summarizeReviewsController);
 
 // 상품 추천
 router.post('/recommend', recommendProductsController);
+
+// 최근 AI 가격 추정 목록 조회
+router.get('/price-estimation/history', getRecentPriceEstimationsController);
 
 export default router;

--- a/src/routes/ai.routes.js
+++ b/src/routes/ai.routes.js
@@ -20,7 +20,7 @@ const router = express.Router();
  * @swagger
  * /api/ai/price-estimation/{productId}:
  *   post:
- *     summary: 상품 AI 적정가 분석 (관리자 전용)
+ *     summary: 상품 AI 적정가 분석 시작 (관리자 전용)
  *     tags: [AI]
  *     security:
  *       - bearerAuth: []
@@ -33,7 +33,7 @@ const router = express.Router();
  *         description: 상품 ID
  *     responses:
  *       200:
- *         description: AI 적정가 분석 결과 반환
+ *         description: AI 적정가 분석 시작 응답
  *         content:
  *           application/json:
  *             schema:
@@ -43,24 +43,18 @@ const router = express.Router();
  *                   type: boolean
  *                 message:
  *                   type: string
+ *                   example: "상품 추정 가격 분석이 진행중입니다."
  *                 data:
  *                   type: object
  *                   properties:
- *                     dailyRentalPrice:
- *                       type: integer
- *                     sources:
- *                       type: object
- *                       properties:
- *                         쿠팡:
- *                           type: integer
- *                         당근마켓:
- *                           type: integer
- *                         중고나라:
- *                           type: integer
- *                     isValid:
- *                       type: boolean
- *                     reason:
+ *                     message:
  *                       type: string
+ *                       example: "상품 추정 가격 분석이 진행중입니다."
+ *                     productId:
+ *                       type: string
+ *                     status:
+ *                       type: string
+ *                       example: "processing"
  *       400:
  *         description: 잘못된 요청(상품 상태 등)
  *       404:
@@ -143,6 +137,74 @@ const router = express.Router();
  *         description: 잘못된 입력(프롬프트 누락 등)
  *       404:
  *         description: 추천할 상품 없음
+ */
+
+/**
+ * @swagger
+ * /api/ai/price-estimation/history:
+ *   get:
+ *     summary: 최근 AI 가격 추정 목록 조회
+ *     tags: [AI]
+ *     parameters:
+ *       - in: query
+ *         name: take
+ *         schema:
+ *           type: integer
+ *           default: 20
+ *         description: 조회할 개수 (기본값: 20)
+ *       - in: query
+ *         name: skip
+ *         schema:
+ *           type: integer
+ *           default: 0
+ *         description: 건너뛸 개수 (페이지네이션용)
+ *     responses:
+ *       200:
+ *         description: 최근 AI 가격 추정 목록 반환
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 success:
+ *                   type: boolean
+ *                 message:
+ *                   type: string
+ *                   example: "최근 AI 가격 추정 목록을 조회했습니다."
+ *                 data:
+ *                   type: object
+ *                   properties:
+ *                     estimations:
+ *                       type: array
+ *                       items:
+ *                         type: object
+ *                         properties:
+ *                           id:
+ *                             type: string
+ *                           productId:
+ *                             type: string
+ *                           productTitle:
+ *                             type: string
+ *                           estimatedPrice:
+ *                             type: integer
+ *                           estimatedDailyRentalPrice:
+ *                             type: integer
+ *                           isValid:
+ *                             type: boolean
+ *                           reason:
+ *                             type: string
+ *                           sources:
+ *                             type: object
+ *                             properties:
+ *                               쿠팡:
+ *                                 type: integer
+ *                               당근마켓:
+ *                                 type: integer
+ *                               중고나라:
+ *                                 type: integer
+ *                           createdAt:
+ *                             type: string
+ *                             format: date-time
  */
 // 적정가 분석
 router.post(

--- a/src/routes/ai.routes.js
+++ b/src/routes/ai.routes.js
@@ -150,14 +150,14 @@ const router = express.Router();
  *         name: take
  *         schema:
  *           type: integer
- *           default: 20
- *         description: 조회할 개수 (기본값: 20)
+ *         description: 조회할 개수
+ *         example: 20
  *       - in: query
  *         name: skip
  *         schema:
  *           type: integer
- *           default: 0
- *         description: 건너뛸 개수 (페이지네이션용)
+ *         description: 건너뛸 개수
+ *         example: 0
  *     responses:
  *       200:
  *         description: 최근 AI 가격 추정 목록 반환
@@ -170,7 +170,6 @@ const router = express.Router();
  *                   type: boolean
  *                 message:
  *                   type: string
- *                   example: "최근 AI 가격 추정 목록을 조회했습니다."
  *                 data:
  *                   type: object
  *                   properties:

--- a/src/services/ai.service.js
+++ b/src/services/ai.service.js
@@ -19,7 +19,23 @@ const openai = new OpenAI({
 //이미지 인식용 테스트용 프롬프트
 // - 그리고 이미지에 보이는 특징(색상, 브랜드, 상태 등)을 한 문장으로 reason에 포함해줘
 
-export const estimatePriceFromAI = async (product) => {
+export const requestAiPriceEstimation = async ({ productId, adminUser }) => {
+  const product = await findProductByIdRepo(productId);
+  if (!product) {
+    throw new CustomError(
+      404,
+      'PRODUCT_NOT_FOUND',
+      AI_MESSAGES.PRODUCT_NOT_FOUND,
+    );
+  }
+  if (product.status !== 'PENDING') {
+    throw new CustomError(
+      400,
+      'INVALID_PRODUCT_STATUS',
+      AI_MESSAGES.INVALID_PRODUCT_STATUS,
+    );
+  }
+
   const { title, description, price, imageUrls } = product;
   const prompt = `
 너는 대여 가격 전문가야.
@@ -90,27 +106,8 @@ export const estimatePriceFromAI = async (product) => {
       `AI 응답을 파싱하는 데 실패했습니다. 실제 응답: ${contentRaw}`,
     );
   }
-  return parsed;
-};
 
-export const requestAiPriceEstimation = async ({ productId, adminUser }) => {
-  const product = await findProductByIdRepo(productId);
-  if (!product) {
-    throw new CustomError(
-      404,
-      'PRODUCT_NOT_FOUND',
-      AI_MESSAGES.PRODUCT_NOT_FOUND,
-    );
-  }
-  if (product.status !== 'PENDING') {
-    throw new CustomError(
-      400,
-      'INVALID_PRODUCT_STATUS',
-      AI_MESSAGES.INVALID_PRODUCT_STATUS,
-    );
-  }
-  const result = await estimatePriceFromAI(product);
-  const { dailyRentalPrice, sources, isValid, reason, ...rest } = result;
+  const { dailyRentalPrice, sources, isValid, reason, ...rest } = parsed;
   await saveAiPriceEstimation({
     ...rest,
     estimatedDailyRentalPrice: dailyRentalPrice,
@@ -121,7 +118,7 @@ export const requestAiPriceEstimation = async ({ productId, adminUser }) => {
     productId,
     userId: adminUser.id,
   });
-  return result;
+  return parsed;
 };
 
 export const summarizeReviews = async (productId) => {

--- a/src/services/ai.service.js
+++ b/src/services/ai.service.js
@@ -19,6 +19,158 @@ const openai = new OpenAI({
 //이미지 인식용 테스트용 프롬프트
 // - 그리고 이미지에 보이는 특징(색상, 브랜드, 상태 등)을 한 문장으로 reason에 포함해줘
 
+// 백그라운드에서 AI 가격 추정을 처리하는 함수
+const processAiPriceEstimation = async ({ productId, adminUser }) => {
+  try {
+    const product = await findProductByIdRepo(productId);
+    if (!product) {
+      console.error(`Product not found: ${productId}`);
+      return;
+    }
+    if (product.status !== 'PENDING') {
+      console.error(`Invalid product status: ${product.status}`);
+      return;
+    }
+
+    const { title, description, price, imageUrls } = product;
+
+    // 이미지 URL 검증
+    const validImageUrl =
+      imageUrls?.length > 0 && imageUrls[0]?.startsWith('http')
+        ? imageUrls[0]
+        : null;
+
+    const prompt = `
+당신은 대여 가격 전문가입니다. 주어진 상품 정보를 바탕으로 적정한 대여 가격을 추정해주세요.
+
+상품 정보:
+- 상품명: ${title}
+- 설명: ${description ?? '설명 없음'}
+- 유저가 입력한 1일 대여 가격: ${price ?? '입력 없음'}
+${validImageUrl ? '- 이미지가 첨부되어 있습니다. 이미지도 참고하여 분석해주세요.' : '- 이미지가 없으므로 상품명과 설명만으로 분석해주세요.'}
+
+다음 기준에 따라 분석해주세요:
+1. 쿠팡, 당근마켓, 중고나라의 중고 판매 가격을 각각 추정
+2. 세 플랫폼의 평균 가격을 기준으로 1일 대여 적정가 계산 (일반적으로 1~5% 수준)
+3. 제품의 파손 위험, 시장 수요, 대체재 여부 등을 고려하여 유연하게 판단
+4. 유저가 제시한 가격이 적정가 대비 20% 이상 차이날 경우 부적절하다고 판단
+
+반드시 아래 JSON 형식으로만 응답해주세요:
+
+{
+  "dailyRentalPrice": 정수,
+  "sources": {
+    "쿠팡": 정수,
+    "당근마켓": 정수,
+    "중고나라": 정수
+  },
+  "isValid": true/false,
+  "reason": "유저 가격의 적정성에 대한 한 문장 설명"
+}
+    `;
+
+    // 멀티모달 메시지 구성
+    const messages = [
+      {
+        role: 'user',
+        content: [
+          { type: 'text', text: prompt },
+          ...(validImageUrl
+            ? [{ type: 'image_url', image_url: { url: validImageUrl } }]
+            : []),
+        ],
+      },
+    ];
+
+    const completion = await openai.chat.completions.create({
+      model: 'gpt-4o',
+      messages,
+      temperature: 0.3,
+      max_tokens: 1000,
+    });
+
+    const contentRaw = completion.choices[0].message.content;
+
+    // AI가 거부하는 경우 처리
+    if (
+      contentRaw.includes("I'm sorry") ||
+      contentRaw.includes("can't assist") ||
+      contentRaw.includes('I cannot')
+    ) {
+      console.error('AI rejected request for product:', productId);
+      return;
+    }
+
+    let content = contentRaw;
+
+    // JSON 블록 추출 (```json ... ``` 또는 ``` ... ```)
+    const jsonMatch = content.match(/```(?:json)?\s*([\s\S]*?)\s*```/);
+    if (jsonMatch) {
+      content = jsonMatch[1].trim();
+    } else {
+      // JSON 블록이 없으면 전체 내용에서 JSON 부분만 추출
+      const jsonStart = content.indexOf('{');
+      const jsonEnd = content.lastIndexOf('}');
+      if (jsonStart !== -1 && jsonEnd !== -1 && jsonEnd > jsonStart) {
+        content = content.substring(jsonStart, jsonEnd + 1);
+      }
+    }
+
+    let parsed;
+    try {
+      parsed = JSON.parse(content);
+    } catch (parseErr) {
+      console.error(
+        'AI parse error for product:',
+        productId,
+        'Response:',
+        contentRaw,
+      );
+      return;
+    }
+
+    // 필수 필드 검증
+    if (
+      !parsed.dailyRentalPrice ||
+      !parsed.sources ||
+      typeof parsed.isValid !== 'boolean' ||
+      !parsed.reason
+    ) {
+      console.error(
+        'AI invalid response for product:',
+        productId,
+        'Response:',
+        contentRaw,
+      );
+      return;
+    }
+
+    // AI 응답에서 필요한 필드만 추출
+    const { dailyRentalPrice, sources, isValid, reason } = parsed;
+
+    // 필요한 필드만 명시적으로 전달
+    const estimationData = {
+      estimatedDailyRentalPrice: dailyRentalPrice,
+      estimatedPrice: dailyRentalPrice,
+      sources: sources || {},
+      isValid: isValid || false,
+      reason: reason || '',
+      productId,
+      userId: adminUser.id,
+    };
+
+    await saveAiPriceEstimation(estimationData);
+    console.log('AI price estimation completed for product:', productId);
+  } catch (error) {
+    console.error(
+      'AI price estimation failed for product:',
+      productId,
+      'Error:',
+      error.message,
+    );
+  }
+};
+
 export const requestAiPriceEstimation = async ({ productId, adminUser }) => {
   const product = await findProductByIdRepo(productId);
   if (!product) {
@@ -36,89 +188,16 @@ export const requestAiPriceEstimation = async ({ productId, adminUser }) => {
     );
   }
 
-  const { title, description, price, imageUrls } = product;
-  const prompt = `
-너는 대여 가격 전문가야.
-
-다음 상품의 이름, 설명, 유저가 입력한 1일 대여 가격, 그리고 이미지를 기반으로
-1) 중고가 기준 1일 대여 적정가를 추정하고,
-2) 유저가 입력한 가격이 적정한지 true/false로 판단하고,
-3) 이유를 한 문장으로 설명해줘.
-
-다음 기준을 따르도록 해:
-- 쿠팡, 당근마켓, 중고나라의 중고 판매 가격을 각기 추정해줘 , 이걸 기반으로 너가 판단하는 적정가는 얼마인지도 적어줘
-- 이 세 개의 평균 가격을 기준으로 1일 대여가는 일반적으로 1~5% 수준이 적정하다고 생각해
-- 단, 제품의 파손 위험, 시장 수요, 대체재 여부 등을 고려해 적정가를 유연하게 판단해도 돼
-- 유저가 제시한 가격이 적정가 대비 20% 이상 차이 날 경우 부적절하다고 판단해
-- 최종적으로 왜 true/false 인지 이유도 간결하게 말해줘
-
-응답은 반드시 아래 형식의 JSON으로만 해줘:
-
-{
-  "dailyRentalPrice": 정수,
-  "sources": {
-    "쿠팡": 정수,
-    "당근마켓": 정수,
-    "중고나라": 정수
-  },
-  "isValid": true/false,
-  "reason": "유저 가격의 적정성에 대한 한 문장 설명"
-}
-
-상품명: ${title}
-설명: ${description ?? '설명 없음'}
-유저가 입력한 1일 대여 가격: ${price ?? '입력 없음'}
-  `;
-
-  // 멀티모달 메시지 구성
-  const messages = [
-    {
-      role: 'user',
-      content: [
-        { type: 'text', text: prompt },
-        ...(imageUrls?.length
-          ? [{ type: 'image_url', image_url: { url: imageUrls[0] } }]
-          : []),
-      ],
-    },
-  ];
-
-  const completion = await openai.chat.completions.create({
-    model: 'gpt-4o',
-    messages,
-    temperature: 0.3,
+  // 백그라운드에서 AI 가격 추정 시작
+  processAiPriceEstimation({ productId, adminUser }).catch((error) => {
+    console.error('Background AI processing error:', error);
   });
-  const contentRaw = completion.choices[0].message.content;
-  let content = contentRaw;
-  if (content.startsWith('```')) {
-    content = content
-      .replace(/```[a-zA-Z]*\n?/, '')
-      .replace(/```/, '')
-      .trim();
-  }
-  let parsed;
-  try {
-    parsed = JSON.parse(content);
-  } catch (err) {
-    throw new CustomError(
-      500,
-      'AI_PARSE_ERROR',
-      `AI 응답을 파싱하는 데 실패했습니다. 실제 응답: ${contentRaw}`,
-    );
-  }
 
-  const { dailyRentalPrice, sources, isValid, reason, ...rest } = parsed;
-  await saveAiPriceEstimation({
-    ...rest,
-    estimatedDailyRentalPrice: dailyRentalPrice,
-    estimatedPrice: dailyRentalPrice,
-    sources,
-    isValid,
-    reason,
+  return {
+    message: AI_MESSAGES.PRICE_ESTIMATION_STARTED,
     productId,
-    userId: adminUser.id,
-  });
-  return parsed;
+    status: 'processing',
+  };
 };
 
 export const summarizeReviews = async (productId) => {

--- a/src/services/ai.service.js
+++ b/src/services/ai.service.js
@@ -42,32 +42,70 @@ const processAiPriceEstimation = async ({ productId, adminUser }) => {
         : null;
 
     const prompt = `
-당신은 대여 가격 전문가입니다. 주어진 상품 정보를 바탕으로 적정한 대여 가격을 추정해주세요.
+You are an expert rental price analyst specializing in the Korean market. Your task is to analyze product information and estimate appropriate daily rental prices based on current market conditions.
 
-상품 정보:
-- 상품명: ${title}
-- 설명: ${description ?? '설명 없음'}
-- 유저가 입력한 1일 대여 가격: ${price ?? '입력 없음'}
-${validImageUrl ? '- 이미지가 첨부되어 있습니다. 이미지도 참고하여 분석해주세요.' : '- 이미지가 없으므로 상품명과 설명만으로 분석해주세요.'}
+## Product Information
+- Product Name: ${title}
+- Description: ${description ?? 'No description'}
+- User's suggested daily rental price: ${price ?? 'Not provided'}
+${validImageUrl ? '- Image is attached. Please analyze considering the visual characteristics as well.' : '- No image available. Analyze based on product name and description only.'}
 
-다음 기준에 따라 분석해주세요:
-1. 쿠팡, 당근마켓, 중고나라의 중고 판매 가격을 각각 추정
-2. 세 플랫폼의 평균 가격을 기준으로 1일 대여 적정가 계산 (일반적으로 1~5% 수준)
-3. 제품의 파손 위험, 시장 수요, 대체재 여부 등을 고려하여 유연하게 판단
-4. 유저가 제시한 가격이 적정가 대비 20% 이상 차이날 경우 부적절하다고 판단
+## Analysis Guidelines
 
-반드시 아래 JSON 형식으로만 응답해주세요:
+### 1. Market Price Estimation
+- Research and estimate used market prices for each platform:
+  * Coupang (쿠팡): Major e-commerce platform, focus on used goods section
+  * Danggeun Market (당근마켓): Local marketplace, often lower prices
+  * Junggonara (중고나라): Traditional used goods platform
+- Consider product condition, age, and market demand
+- Use realistic price ranges based on current market trends
+
+### 2. Daily Rental Price Calculation
+- Base calculation: 1-5% of the average market price
+- Adjust based on factors:
+  * High-value items (>500,000 KRW): 0.5-2% of market price
+  * Mid-value items (100,000-500,000 KRW): 1-3% of market price
+  * Low-value items (<100,000 KRW): 2-5% of market price
+- Consider rental duration flexibility and demand patterns
+
+### 3. Risk Assessment Factors
+- Product fragility and damage potential
+- Market demand and seasonal trends
+- Availability of similar products
+- Brand reputation and reliability
+- Maintenance requirements
+
+### 4. Price Validation
+- Compare user's suggested price with calculated estimate
+- Mark as invalid if user's price is more than 50% higher than estimated price
+- Mark as valid if user's price is 70% or less of estimated price (good deal for renters)
+- Consider market volatility and acceptable price ranges
+
+### 5. Response Requirements
+- Provide specific, actionable reasoning
+- Include market context in explanation
+- Ensure all numerical values are integers
+- Maintain consistency in pricing logic
+
+## Output Format
+Respond ONLY in the following JSON format:
 
 {
-  "dailyRentalPrice": 정수,
+  "dailyRentalPrice": integer,
   "sources": {
-    "쿠팡": 정수,
-    "당근마켓": 정수,
-    "중고나라": 정수
+    "쿠팡": integer,
+    "당근마켓": integer,
+    "중고나라": integer
   },
   "isValid": true/false,
-  "reason": "유저 가격의 적정성에 대한 한 문장 설명"
+  "reason": "한국어로 유저 가격의 적정성에 대한 구체적이고 명확한 설명 (시장 상황, 가격 비교, 추천 근거 포함)"
 }
+
+## Important Notes
+- All prices should be in Korean Won (KRW)
+- Daily rental price should be reasonable for both owner and renter
+- Consider the competitive rental market in Korea
+- Provide detailed reasoning for price validation decisions
     `;
 
     // 멀티모달 메시지 구성
@@ -247,28 +285,65 @@ export const recommendProducts = async ({ prompt, userId }) => {
     })
     .join('\n');
   const gptPrompt = `
-당신은 상품 추천 도우미입니다.
+You are an expert product recommendation assistant specializing in rental services. Your task is to analyze user requests and recommend the most suitable products from the available inventory.
 
-아래는 대여 가능한 상품 목록입니다.
-각 상품은 ID, 제목, 설명으로 구성되어 있습니다.
-
---- 상품 목록 ---
+## Available Products
+Below is a comprehensive list of rental products available in our system:
 ${itemsText}
 
---- 사용자 요청 ---
-"${prompt}"
+## User Request Analysis
+Request: "${prompt}"
 
-위 요청에 맞게 적절한 상품 3개를 추천해 주세요.
-단, 정말로 적합한 상품이 없다면 빈 배열([])로만 응답하세요.
+## Recommendation Guidelines
 
-추천할 때는 상품의 ID를 기준으로 출력하고, 간단한 추천 이유도 함께 작성하세요.
+### 1. Relevance Assessment
+- Analyze the user's specific needs and preferences
+- Consider product category, features, and use cases
+- Match request keywords with product descriptions
+- Prioritize products that directly address the user's requirements
 
-출력 형식 (JSON만 반환):
+### 2. Quality and Reliability
+- Consider product condition and reliability
+- Factor in brand reputation and user reviews
+- Assess rental history and availability
+- Prioritize products with good track records
+
+### 3. Value Proposition
+- Consider price-to-value ratio
+- Assess competitive advantages of each product
+- Factor in rental duration flexibility
+- Consider seasonal demand and availability
+
+### 4. Selection Criteria
+- Maximum 3 recommendations to avoid choice paralysis
+- Ensure diversity in recommendations when possible
+- Consider different price points if applicable
+- Focus on products that best match the request
+
+### 5. Response Quality
+- Provide specific, actionable reasoning for each recommendation
+- Include relevant product features that match the request
+- Consider user's potential use case and requirements
+- Ensure recommendations are practical and realistic
+
+## Output Requirements
+- Return exactly 3 products or empty array if no suitable matches
+- Use exact product IDs from the provided list
+- Provide detailed reasoning in Korean language
+- Focus on user benefits and practical advantages
+
+## Output Format
+Respond ONLY in the following JSON format:
+
 [
-  { "id": "상품ID", "reason": "추천 이유" },
+  { 
+    "id": "exact_product_id", 
+    "reason": "한국어로 구체적이고 명확한 추천 이유 (제품 특징, 사용자 요청과의 연관성, 실용적 장점 포함)" 
+  },
   ...
 ]
-적합한 상품이 없으면 [] 만 반환
+
+If no suitable products match the request, return: []
 `;
   const completion = await openai.chat.completions.create({
     model: 'gpt-4o',

--- a/src/services/ai.service.js
+++ b/src/services/ai.service.js
@@ -6,6 +6,7 @@ import {
 import {
   saveAiPriceEstimation,
   saveAiProductRecommendation,
+  getRecentAiPriceEstimations,
 } from '../repositories/ai.repository.js';
 import { getReviewsByProductIdRepo } from '../repositories/review.repository.js';
 import CustomError from '../utils/customError.js';
@@ -296,4 +297,42 @@ ${itemsText}
     userId: userId ?? null,
   });
   return { recommendedProductIds, reason };
+};
+
+export const getRecentPriceEstimations = async ({ take = 20, skip = 0 }) => {
+  const estimations = await getRecentAiPriceEstimations({ take, skip });
+
+  // 각 상품별로 최신 결과만 필터링
+  const productMap = new Map();
+
+  estimations.forEach((estimation) => {
+    const productId = estimation.productId;
+
+    // 이미 해당 상품의 결과가 있으면 더 최신 것만 유지
+    if (
+      !productMap.has(productId) ||
+      productMap.get(productId).createdAt < estimation.createdAt
+    ) {
+      productMap.set(productId, estimation);
+    }
+  });
+
+  // Map의 값들을 배열로 변환하고 시간순 정렬
+  const uniqueEstimations = Array.from(productMap.values())
+    .sort((a, b) => new Date(b.createdAt) - new Date(a.createdAt))
+    .slice(0, take);
+
+  return {
+    estimations: uniqueEstimations.map((estimation) => ({
+      id: estimation.id,
+      productId: estimation.productId,
+      productTitle: estimation.product.title,
+      estimatedPrice: estimation.estimatedPrice,
+      estimatedDailyRentalPrice: estimation.estimatedDailyRentalPrice,
+      isValid: estimation.isValid,
+      reason: estimation.reason,
+      sources: estimation.sources,
+      createdAt: estimation.createdAt,
+    })),
+  };
 };

--- a/src/services/product.service.js
+++ b/src/services/product.service.js
@@ -51,8 +51,24 @@ export const createProduct = async (productData, user) => {
     throw new CustomError(400, 'INVALID_PRICE', PRODUCT_MESSAGES.INVALID_PRICE);
   }
 
+  // allowPurchase 값 검증 및 변환
+  let allowPurchase = false;
+  if (productData.allowPurchase !== undefined) {
+    if (typeof productData.allowPurchase === 'string') {
+      allowPurchase = productData.allowPurchase === 'true';
+    } else if (typeof productData.allowPurchase === 'boolean') {
+      allowPurchase = productData.allowPurchase;
+    } else {
+      throw new CustomError(
+        400,
+        'INVALID_ALLOW_PURCHASE',
+        PRODUCT_MESSAGES.INVALID_ALLOW_PURCHASE,
+      );
+    }
+  }
+
   // allowPurchase가 true인 경우 purchasePrice 검증
-  if (productData.allowPurchase) {
+  if (allowPurchase) {
     if (!productData.purchasePrice) {
       throw new CustomError(
         400,
@@ -116,7 +132,7 @@ export const createProduct = async (productData, user) => {
         ? Number(productData.purchasePrice)
         : null,
       imageUrls: productData.imageUrls || [],
-      allowPurchase: productData.allowPurchase || false,
+      allowPurchase: allowPurchase,
       categoryId,
       status,
     },


### PR DESCRIPTION
ai 가격추정을 전반적으로 수정하였습니다.
해당 기능은 어드민이 대기중인 상품을 승인/거절하는데에 있어서 더 원할하게 하기 위함이었는데,
이미지 파싱으로 정확도를 올리다보니 API 속도가 현격히 떨어졌었습니다.
해서 응답은 바로오게만들도 가격추정은 백그라운드에서 진행하는것으로 설계하였습니다.
이제 어드민은 대기하지 않아도 되고 가격추정을 여러개 눌러놓고 대기중 상품조회에 가서  승인/거절 작업을 진행하면 됩니다. 
사실상 API 속도가 치명적으로 느린것은 아니라(5초) 작업을 진행할때 가격추정은 대부분 완료가 될 것입니다. 

또 프롬프트 전반을 수정하였습니다 한글 -> 영어/한글 섞어서. 
그리고 보다 많은 디테일을 추가하였고 기준도 완화하였습니다.  
저렴할경우 그냥 통과 70% 비쌀경우 50%까지 허용
파손위험도 계절유행 대체제유무 브랜드의 신뢰도 가격별 다른 적정가 등